### PR TITLE
Add webkit vendor prefix to backdrop blur

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -41,6 +41,7 @@ body {
   width: 100%;
   background: linear-gradient(to right, hsla(0, 0%, 100%, 0.32), hsla(0, 0%, 88%, 0.5));
   backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
   vertical-align: middle;
 }
 
@@ -105,6 +106,7 @@ h1 {
   top: 0;
   background: linear-gradient(to right, hsla(0, 0%, 0%, 0.5), hsla(0, 0%, 0%, 0.4));
   backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
   animation: i .5s;
   overflow-y: auto;
   flex-flow: column nowrap;


### PR DESCRIPTION
This, (if it works correctly) fixes the lack of blur on iPad, the primary device for hopscotch.

edit: it might take a while for you to see this lol